### PR TITLE
feat: enforce: Prevent ContractDebugMode

### DIFF
--- a/modules/light-clients/08-wasm/keeper/keeper_vm.go
+++ b/modules/light-clients/08-wasm/keeper/keeper_vm.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"os"
 
 	wasmvm "github.com/CosmWasm/wasmvm/v2"
 
@@ -88,6 +89,9 @@ func NewKeeperWithConfig(
 	queryRouter types.QueryRouter,
 	opts ...Option,
 ) Keeper {
+	if wasmConfig.ContractDebugMode && os.Getenv("IBC_WASM_ALLOW_DEBUG") != "true" {
+		panic("ContractDebugMode must not be enabled in production! Set IBC_WASM_ALLOW_DEBUG=true to override for testing.")
+	}
 	vm, err := wasmvm.NewVM(wasmConfig.DataDir, wasmConfig.SupportedCapabilities, types.ContractMemoryLimit, wasmConfig.ContractDebugMode, types.MemoryCacheSize)
 	if err != nil {
 		panic(fmt.Errorf("failed to instantiate new Wasm VM instance: %v", err))


### PR DESCRIPTION
Description
This PR adds a runtime safety check to the Wasm light client module to ensure that ContractDebugMode cannot be enabled in production environments.
Specifically, in NewKeeperWithConfig, the application will now panic if ContractDebugMode is set to true and the environment variable IBC_WASM_ALLOW_DEBUG is not explicitly set to "true".
This prevents accidental leakage of contract debug output and enforces best practices for production deployments.
Critical file to review:
modules/light-clients/08-wasm/keeper/keeper_vm.go